### PR TITLE
Fix/fi 0001/new release process (#8)

### DIFF
--- a/.github/workflows/release-prepare.yml
+++ b/.github/workflows/release-prepare.yml
@@ -57,8 +57,7 @@ jobs:
       - name: Create Release
         uses: actions/create-release@v1
         with:
-          tag_name: ${{ github.ref }}
-          release_name: ${{ github.ref }}
+          release_name: Release ${{ steps.version-bump.outputs.newTag }}
           body: ${{steps.github_release.outputs.changelog}}
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "release-workflow-testing",
-  "version": "0.1.0",
+  "version": "0.2.1",
   "private": true,
   "scripts": {
     "dev": "next dev",


### PR DESCRIPTION
* CI: bumps version to 0.2.0 [skip ci]

* CI: bumps version to 0.2.1 [skip ci]

* fix release branch in workflow

Co-authored-by: Automated Version Bump <gh-action-bump-version@users.noreply.github.com>